### PR TITLE
New storage backends

### DIFF
--- a/experiment_runner/experiment_runner.py
+++ b/experiment_runner/experiment_runner.py
@@ -145,7 +145,7 @@ def eval_fit(config):
         if not os.path.exists(out_path):
             os.makedirs(out_path)
 
-        with open(out_path + "/config.json", 'w') as out:
+        with open(os.path.join(out_path,  "config.json"), 'w') as out:
             out.write(json.dumps(replace_objects(readable_cfg), indent=4))
 
         scores = {}
@@ -280,7 +280,7 @@ def run_experiments(basecfg, cfgs, **kwargs):
             for result in tqdm(to_iterator(configurations), total=len(configurations)):
                 if result is not None:
                     experiment_id, results, out_file_content = result
-                    with open(basecfg["out_path"] + "/results.jsonl", "a", 1) as out_file:
+                    with open(os.path.join(basecfg["out_path"], "results.jsonl"), "a", 1) as out_file:
                         out_file.write(out_file_content)
         elif backend == "malocher":
             malocher_dir = basecfg.get("malocher_dir", ".malocher_dir")
@@ -300,7 +300,7 @@ def run_experiments(basecfg, cfgs, **kwargs):
             for job_id, eval_return in tqdm(results, total=len(configurations), disable=not verbose):
                 if eval_return is not None:
                     experiment_id, results, out_file_content = eval_return
-                    with open(basecfg["out_path"] + "/results.jsonl", "a", 1) as out_file:
+                    with open(os.path.join(basecfg["out_path"], "results.jsonl"), "a", 1) as out_file:
                         out_file.write(out_file_content)
 
 
@@ -309,14 +309,14 @@ def run_experiments(basecfg, cfgs, **kwargs):
             for eval_return in tqdm(pool.imap_unordered(eval_fit, configurations), total=len(configurations), disable=not verbose):
                 if eval_return is not None:
                     experiment_id, results, out_file_content = eval_return
-                    with open(basecfg["out_path"] + "/results.jsonl", "a", 1) as out_file:
+                    with open(os.path.join(basecfg["out_path"], "results.jsonl"), "a", 1) as out_file:
                         out_file.write(out_file_content)
         else:
             for f in tqdm(configurations, disable=not verbose):
                 eval_return = eval_fit(f)
                 if eval_return is not None:
                     experiment_id, results, out_file_content = eval_return
-                    with open(basecfg["out_path"] + "/results.jsonl", "a", 1) as out_file:
+                    with open(os.path.join(basecfg["out_path"], "results.jsonl"), "a", 1) as out_file:
                         out_file.write(out_file_content)
     except Exception as e:
         return_str = str(e) + "\n"

--- a/experiment_runner/experiment_runner.py
+++ b/experiment_runner/experiment_runner.py
@@ -1,4 +1,5 @@
 """Experiment Runner. It's great!"""
+import datetime
 import os
 import inspect
 import random
@@ -212,7 +213,7 @@ def run_experiments(basecfg: dict, cfgs, **kwargs):
         elif basecfg["storage_backend"] == "mongodb":
             storage_backend = MongoDBStorageBackend(basecfg.get("mongo_host", "localhost"),
                                                     basecfg.get("mongo_port", 27017),
-                                                    basecfg.get("mongo_database", "experiment_runner"))
+                                                    basecfg.get("mongo_database", f"experiment_runner_{'{0:%d%m%Y_%H%M%S}'.format(datetime.datetime.now())}"))
             if verbose:
                 print(f"Storage backend: '{basecfg['storage_backend']}' connected to '{storage_backend.host}:{storage_backend.port}' and database '{storage_backend.database}'.")
         else:

--- a/experiment_runner/experiment_runner.py
+++ b/experiment_runner/experiment_runner.py
@@ -204,7 +204,7 @@ def run_experiments(basecfg: dict, cfgs, **kwargs):
         # Initialize storage backend.
         if basecfg["storage_backend"] == "fs":
             if "out_path" in basecfg.keys():
-                storage_backend = FSStorageBackend(basecfg["out_path"])
+                storage_backend = FSStorageBackend(basecfg["out_path"], basecfg.get("fs_force", False))
                 if verbose:
                     print(f"Storage backend: '{basecfg['storage_backend']}' with output path '{basecfg['out_path']}'.")
             else:

--- a/experiment_runner/experiment_runner.py
+++ b/experiment_runner/experiment_runner.py
@@ -203,7 +203,7 @@ def eval_fit(config):
 
 
 
-def run_experiments(basecfg, cfgs, **kwargs):
+def run_experiments(basecfg: dict, cfgs, **kwargs):
     """
     The main API call of the experiment_runner.
     Pass a base_cfg to configure the execution of the experiments.
@@ -215,11 +215,18 @@ def run_experiments(basecfg, cfgs, **kwargs):
         return_str = ""
         # results = []
 
-        # Initialize default storage backend.
-        if "out_path" in basecfg.keys():
-            storage_backend = FSStorageBackend(basecfg["out_path"])
+        # Initialize storage backend.
+        if "storage_backend" not in basecfg.keys():
+            print("No 'storage_backend' specified in base config. Defaulting to 'fs'.")
+            basecfg["storage_backend"] = "fs"
+
+        if basecfg["storage_backend"] == "fs":
+            if "out_path" in basecfg.keys():
+                storage_backend = FSStorageBackend(basecfg["out_path"])
+            else:
+                raise ValueError("Could not initialize storage backend 'fs'. Key 'out_path' missing in base config.")
         else:
-            raise ValueError("Could not initialize storage backend. Key 'out_path' missing in base config.")
+            raise ValueError(f"Unable to initialize storage backend. Unknown backend '{basecfg['storage_backend']}' provided.")
 
         # pool = NonDaemonPool(n_cores, initializer=init, initargs=(l,shared_list))
         # Lets use imap and not starmap to keep track of the progress

--- a/experiment_runner/experiment_runner.py
+++ b/experiment_runner/experiment_runner.py
@@ -223,8 +223,8 @@ def run_experiments(basecfg, cfgs, **kwargs):
         if not os.path.exists(basecfg["out_path"]):
             os.makedirs(basecfg["out_path"])
         else:
-            if os.path.isfile(basecfg["out_path"] + "/results.jsonl"):
-                os.unlink(basecfg["out_path"] + "/results.jsonl")
+            if os.path.isfile(os.path.join(basecfg["out_path"], "results.jsonl")):
+                os.unlink(os.path.join(basecfg["out_path"], "results.jsonl"))
 
         # pool = NonDaemonPool(n_cores, initializer=init, initargs=(l,shared_list))
         # Lets use imap and not starmap to keep track of the progress

--- a/experiment_runner/storage_backends.py
+++ b/experiment_runner/storage_backends.py
@@ -36,13 +36,17 @@ class StorageBackend(ABC):
 
 
 class FSStorageBackend(StorageBackend):
-    def __init__(self, out_path):
+    def __init__(self, out_path, force=False):
         """
         Initializes a storage backend which uses the local filesystem to store experiments and their results.
 
         :param out_path: Directory path, which will be used to store experiments and result.
+        :param force: Allows initialization of the storage backend even when the output path is existent and not empty.
         """
         self.out_path = os.path.abspath(out_path)
+
+        if not force and os.path.exists(self.out_path) and os.listdir(self.out_path):
+            raise ValueError(f"FSStorageBackend: Output directory at '{self.out_path}' does already exist and is not empty.")
 
         if not os.path.exists(self.out_path):
             os.makedirs(self.out_path)

--- a/experiment_runner/storage_backends.py
+++ b/experiment_runner/storage_backends.py
@@ -1,0 +1,43 @@
+import json
+import os
+from abc import ABC, abstractmethod
+
+
+class StorageBackend(ABC):
+    @abstractmethod
+    def write_experiment_config(self, cfg: dict):
+        pass
+
+    @abstractmethod
+    def add_result(self, result: dict):
+        pass
+
+
+class FSStorageBackend(StorageBackend):
+    def __init__(self, out_path):
+        self.out_path = os.path.abspath(out_path)
+
+        if not os.path.exists(self.out_path):
+            os.makedirs(self.out_path)
+        else:
+            if os.path.isfile(os.path.join(self.out_path, "results.jsonl")):
+                os.unlink(os.path.join(self.out_path, "results.jsonl"))
+
+    def write_experiment_config(self, cfg: dict):
+        # Get experiment id from config.
+        experiment_id = cfg["experiment_id"]
+
+        # Construct output path.
+        out_path = os.path.join(self.out_path, str(experiment_id))
+
+        # Check, whether the path exists otherwise create the directories..
+        if not os.path.exists(out_path):
+            os.makedirs(out_path)
+
+        # Write the config to disk.
+        with open(os.path.join(out_path, "config.json"), 'w') as out:
+            out.write(json.dumps(cfg, indent=4))
+
+    def add_result(self, result: dict):
+        with open(os.path.join(self.out_path, "results.jsonl"), "a", 1) as out_file:
+            out_file.write(json.dumps(result, sort_keys=True) + "\n")

--- a/experiment_runner/storage_backends.py
+++ b/experiment_runner/storage_backends.py
@@ -8,6 +8,9 @@ from pymongo import MongoClient
 
 
 class StorageBackend(ABC):
+    """
+    Abstract base class (ABC) for storage backends.
+    """
     @abstractmethod
     def write_experiment_config(self, cfg: dict):
         pass
@@ -17,6 +20,12 @@ class StorageBackend(ABC):
         pass
 
     def __json_encoder__(self, v):
+        '''
+        Custom JSON encoder, which may be used together with JSON.dump(s) + default. Commonly used for storing results through serialization.
+        Handles some of the types, which are usually used within experimental routines.
+        :param v: Object to serialize.
+        :return: JSON-friendly object, which can be serialized using the json package.
+        '''
         if isinstance(v, np.generic):
             return v.item()
         elif isinstance(v, np.ndarray):
@@ -45,9 +54,11 @@ class FSStorageBackend(StorageBackend):
         """
         self.out_path = os.path.abspath(out_path)
 
+        # Check, whether initialization should be refused.
         if not force and os.path.exists(self.out_path) and os.listdir(self.out_path):
             raise ValueError(f"FSStorageBackend: Output directory at '{self.out_path}' does already exist and is not empty.")
 
+        # Create necessary directory structures.
         if not os.path.exists(self.out_path):
             os.makedirs(self.out_path)
         else:

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='experiment_runner',
       ],
       extras_require={
             "ray": ["ray"],
-            "malocher": ["malocher @ git+https://github.com/Whadup/malocher@main#egg=malocher"]
+            "malocher": ["malocher @ git+https://github.com/Whadup/malocher@main#egg=malocher"],
+            "pymongo": ["pymongo"]
       }
 )


### PR DESCRIPTION
I have introduced a simple abstraction for all storage-related operations within `experiment_runner`. This allows for exchanging the storage backend in a flexible fashion. For now, I have added the FSStorageBackend (which merely represents the already existing storage mechanism) but also a MongoDBStorageBackend, which allows to store experiments and their results in MongoDB. 

Storage backends can be chosen by adjusting the `storage_backend` key in the experiments' base configuration. Valid options are currently `["fs", "mongodb"]` with `fs` being the default choice.

I have also made some adjustments with respect to how directories are created. Some experiments might rely on `experiment_runner` creating a "working directory" for them. These working directories are now only created when `FSStorageBackend` is chosen. It is certainly possible to store BLOBs in MongoDB, but I have not included any `StorageBackend` call to support this. This might be an interesting thing for the future.

Moreover, `replace_objects` has now given way to a more canonical approach to serialize non-default JSON / Python types (ae8d46e).